### PR TITLE
Initial improvement to DIDDoc upsert

### DIFF
--- a/src/did/did.controller.ts
+++ b/src/did/did.controller.ts
@@ -17,7 +17,7 @@ import {
 } from '@nestjs/swagger';
 import { Queue } from 'bull';
 import { NotFoundInterceptor } from 'src/interceptors/not-found.interceptor';
-import { DIDService } from './did.service';
+import { DIDService, upsert_queue_channel } from './did.service';
 import { DID } from './DidTypes';
 
 @Controller('DID')
@@ -93,6 +93,6 @@ export class DIDController {
   @HttpCode(202)
   public async upsertById(@Param('id') id: string) {
     this.logger.debug(`queueing upsert for ${id}`);
-    await this.didQueue.add('refreshDocument', id);
+    await this.didQueue.add(upsert_queue_channel, id);
   }
 }


### PR DESCRIPTION
Still in draft.

Acceptance tests:
- [ ] Cache DIDDoc that has no logs (no interaction with ERC 1056) → Should still cache document with “topBlock” set
- [ ] Cache DIDDoc with new Service Attribute
- [ ] Cache DIDDoc with new Auth Attribute
- [ ] Cache DIDDoc with new PubKey Attribute
- [ ] Cache DIDDoc with new Delegate
- [ ] DIDDoc with no new logs should not trigger update