### PR TITLE
[MYEN-524] remove posibility to delete anything through CI/CD

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ export IAM_CACHE_SERVER_IMAGE=$4
 aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $IAM_CACHE_SERVER_IMAGE
 
 # Creating backup
-make backup
+make backup-ci
 
 # Stopping docker compose
 docker-compose stop

--- a/makefile
+++ b/makefile
@@ -8,7 +8,12 @@ backup:
 	/usr/bin/docker-compose exec -T dgraph curl http://localhost:8080/admin/export
 	/usr/bin/docker cp -a dgraph_alpha:/dgraph/export/. ./db_dumps
 	/usr/bin/docker-compose exec -T dgraph rm -rf export
-	find ./db_dumps/* -type d -ctime +7 -exec rm -rf {} \;
+	find ./db_dumps/* -type d -ctime +2 -exec rm -rf {} \;
+
+backup-ci:
+	/usr/bin/docker-compose exec -T dgraph curl http://localhost:8080/admin/export
+	/usr/bin/docker cp -a dgraph_alpha:/dgraph/export/. ./db_dumps
+	/usr/bin/docker-compose exec -T dgraph rm -rf export
 
 restore:
 	FOLDER=$$(ls -t db_dumps | head -1); \


### PR DESCRIPTION
As @jrhender pointed out we have an `access denied` error while removing old db dumps running in CI/CD.
So I was thinking that this is not a bad idea ;) we shouldn't be able to remove that important data while using CI/CD. We still have a cron job that is doing that every 12 hours, so I've added a script to backup db without removing it from the server in CI/CD env