### PR TITLE
Awaiting refresh of didDoc cache to avoid duplication

### DIFF
--- a/src/did/did.controller.ts
+++ b/src/did/did.controller.ts
@@ -69,8 +69,8 @@ export class DIDController {
         this.logger.log(
           `Requested document for did: ${id} not cached. Queuing cache request.`,
         );
-        //Not awaiting result of add because it does not affect result returned to client
-        this.didQueue.add('refreshDocument', id);
+        // awaiting refresh so that subsequent calls don't duplicate cached DID Document
+        await this.didService.refreshCachedDocument(did);
       }
 
       this.logger.debug(`Retrieved document for did: ${id}`);


### PR DESCRIPTION
See https://energyweb.atlassian.net/browse/MYEN-534 for context on this bug.

This change is a quick fix for the issue. If going with it, it might make sense to retrieve & return the DID Doc instead of returning 404 if not cached.

A better solution would be to fix with Dgraph transactions, possibly with an upsert query.
https://dgraph.io/docs/clients/overview/#transactions
https://dgraph.io/docs/howto/upserts/
