### PR TITLE
Changing CommonJS imports to ES Module syntax

### DIFF
--- a/src/claim/claim.service.ts
+++ b/src/claim/claim.service.ts
@@ -7,7 +7,7 @@ import {
   IClaimRequest,
   DecodedClaimToken,
 } from './ClaimTypes';
-import * as jwt_decode from 'jwt-decode';
+import jwt_decode from 'jwt-decode';
 
 const claimQuery = `
   uid

--- a/src/dgraph/dgraph.service.ts
+++ b/src/dgraph/dgraph.service.ts
@@ -3,7 +3,7 @@ import { DgraphClient, DgraphClientStub, Mutation, Operation } from 'dgraph-js';
 import { ConfigService } from '@nestjs/config';
 import { Policy } from 'cockatiel';
 import { promisify } from 'util';
-import * as fs from 'fs';
+import fs from 'fs';
 
 @Injectable()
 export class DgraphService implements OnModuleInit {

--- a/src/did/did.service.ts
+++ b/src/did/did.service.ts
@@ -11,7 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { EthereumDidRegistryFactory } from '../ethers/EthereumDidRegistryFactory';
 import { EthereumDidRegistry } from '../ethers/EthereumDidRegistry';
-import * as jwt_decode from 'jwt-decode';
+import jwt_decode from 'jwt-decode';
 import { providers } from 'ethers';
 import { DIDDocumentEntity } from './DidDocumentEntity';
 import { ResolverFactory } from './ResolverFactory';

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '../src/app.module';
 
 describe('AppController (e2e)', () => {


### PR DESCRIPTION
The addition of  `"esModuleInterop": true` means that we should import CommonJS modules in compliance with es6 modules spec. This is currently causing bug in where full claims are not returned when retrieving DID Document.