### PR TITLE
fix(did caching): improving DID Document retrieval

### DIFF
--- a/src/did/DidTypes.ts
+++ b/src/did/DidTypes.ts
@@ -1,10 +1,11 @@
+import { getAddress } from 'ethers/utils';
+
 /**
  * A value object representing EIP-1056 DID
  */
 export class DID {
   constructor(id: string) {
-    this.validate(id);
-    this.id = id;
+    this.id = this.normalize(id);
   }
 
   /**
@@ -12,16 +13,24 @@ export class DID {
    */
   readonly id: string;
 
-  validate(id: string) {
+  /**
+   * Verifies that DID conforms to EIP-1056 and normalizes address
+   * @param id 
+   */
+  normalize(id: string): string {
     const parts = id.split(':');
     if (parts.length != 3) {
       throw new Error('DID should consists of 3 components');
     }
-    if (parts[0] != 'did') {
+    if (parts[0] !== 'did') {
       throw new Error('DID should begin with "did:"');
     }
-    if (parts[1] != 'ethr') {
+    if (parts[1] !== 'ethr') {
       throw new Error('DID method should be "ethr"');
     }
+    try {
+      parts[2] = getAddress(parts[2]);
+    } catch (e) { throw new Error('DID identifier should be valid address'); }
+    return parts.join(':')
   }
 }

--- a/src/did/did.controller.ts
+++ b/src/did/did.controller.ts
@@ -62,15 +62,15 @@ export class DIDController {
       );
       const did = new DID(id);
       const includeClaims = includeClaimsString === 'true';
-      const didDocument = await this.didService.getById(did, includeClaims);
+      let didDocument = await this.didService.getById(did, includeClaims);
 
-      // If DID document isn't in the cache, queue cache so that it can be retrieved on subsequent calls
       if (!didDocument) {
         this.logger.log(
           `Requested document for did: ${id} not cached. Queuing cache request.`,
         );
         // awaiting refresh so that subsequent calls don't duplicate cached DID Document
         await this.didService.refreshCachedDocument(did);
+        didDocument = await this.didService.getById(did, includeClaims);
       }
 
       this.logger.debug(`Retrieved document for did: ${id}`);


### PR DESCRIPTION
- On GET retrieving DID Doc after caching so that clients (e.g. iam-client-lib) doesn't have to
- Adding additional validation&normalization on address component of DID