### PR TITLE
feat(auth): protect deleting endpoint

### DIFF
--- a/src/auth/login.controller.ts
+++ b/src/auth/login.controller.ts
@@ -1,10 +1,22 @@
 import { Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { LoginGuard } from './login.guard';
 import { Request } from 'express';
+import { ApiBody } from '@nestjs/swagger';
 
 @Controller()
 export class LoginController {
   @UseGuards(LoginGuard)
+  @ApiBody({
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        identityToken: {
+          type: 'string',
+        },
+      },
+    },
+  })
   @Post('login')
   async login(@Req() req: Request) {
     return { token: req.user as string };

--- a/src/claim/claim.controller.ts
+++ b/src/claim/claim.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Post,
   Query,
+  Req,
 } from '@nestjs/common';
 import { ClaimService } from './claim.service';
 import {
@@ -178,8 +179,11 @@ export class ClaimController {
   @Delete('/:id')
   @ApiExcludeEndpoint()
   @ApiTags('Claims')
-  public async removeById(@Param('id') id: string) {
-    return await this.claimService.removeById(id);
+  public async removeById(
+    @Param('id') id: string,
+    @Req() req: { user: { did: string } },
+  ) {
+    return await this.claimService.removeById(id, req?.user?.did);
   }
 
   @Get('/parent/:namespace')


### PR DESCRIPTION
Only logged user which is a requester for certain not accepted and not rejected claim can cancel it.