### PR TITLE
feat(didSync): add concurrency limit to refresh processing

### DIFF
--- a/src/did/did.processor.ts
+++ b/src/did/did.processor.ts
@@ -8,21 +8,27 @@ import { DID } from './DidTypes';
 export class DIDProcessor {
   private readonly logger: Logger;
 
-  constructor(private readonly didService: DIDService) {
+  constructor(
+    private readonly didService: DIDService
+  ) {
     this.logger = new Logger('DIDProcessor');
   }
 
-  @Process('upsertDocument')
+  @Process({ name: 'upsertDocument', concurrency: 0 })
   public async processDIDDocumentUpsert(job: Job<string>) {
     this.logger.log(`processing cache upsert for ${job.data}`);
     const did = new DID(job.data);
-    this.didService.upsertCachedDocument(did);
+    await this.didService.upsertCachedDocument(did);
   }
 
-  @Process('refreshDocument')
+  // Note that bull queue concurrency stacks for all methods in a processor:
+  // - https://github.com/nestjs/bull/issues/258
+  // - https://github.com/OptimalBits/bull/issues/1113#issuecomment-440706459
+  @Process({ name: 'refreshDocument', concurrency: 3 })
   public async processDIDDocumentRefresh(job: Job<string>) {
     this.logger.log(`processing cache refresh for ${job.data}`);
     const did = new DID(job.data);
-    this.didService.refreshCachedDocument(did);
+    await this.didService.refreshCachedDocument(did);
+    this.logger.debug(`finished cache refresh for: ${job.data}`);
   }
 }


### PR DESCRIPTION
I don't have any great evidence for it but I think it is possible that DGraph locking up could be the cause of the iam-cache-server going down. To reduce what might be a cause of strain on DGraph, I am thinking that it might be a good idea to limit the number of DidDoc refreshes that occur concurrently so that DGraph (and the blockchain RPC) it only given a new request once it is done processing a previous one. Do you think this is a good idea?