### PR TITLE
feature/improve claim api

### DIFF
--- a/src/modules/claim/claim.controller.ts
+++ b/src/modules/claim/claim.controller.ts
@@ -255,6 +255,39 @@ export class ClaimController {
       currentUser: user,
     });
   }
+  
+  @Get('/subject/:did')
+  @ApiTags('Claims')
+  @ApiOperation({
+    summary: 'returns claims for given subject',
+  })
+  @ApiQuery({
+    name: 'accepted',
+    required: false,
+    description:
+      '**true** - show only accepted <br> **false** - show only pending',
+  })
+  @ApiQuery({
+    name: 'namespace',
+    required: false,
+    description: 'filter only claims of given namespace',
+  })
+  public async getBySubject(
+    @Param('did') subject: string,
+    @Query('accepted', BooleanPipe)
+    accepted?: boolean,
+    @Query('namespace') parentNamespace?: string,
+    @User() user?: string,
+  ) {
+    return await this.claimService.getBySubject({
+      subject,
+      filters: {
+        accepted,
+        parentNamespace,
+      },
+      currentUser: user,
+    });
+  }
 
   @Get('/did/:namespace')
   @ApiQuery({

--- a/src/modules/claim/claim.entity.ts
+++ b/src/modules/claim/claim.entity.ts
@@ -1,6 +1,8 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, PrimaryColumn, AfterLoad } from 'typeorm';
 import { IClaim } from './claim.types';
+import { JWT } from '@ew-did-registry/jwt';
+import { Keys } from '@ew-did-registry/keys';
 
 @ObjectType()
 @Entity()
@@ -10,6 +12,12 @@ export class Claim implements IClaim {
     Object.assign(entity, data);
     return entity;
   }
+  
+  @AfterLoad()
+  init() {
+    const jwt = new JWT(new Keys());
+    this.subject = jwt.decode(this.token).sub as string;
+  }
 
   @Field()
   @PrimaryColumn()
@@ -18,6 +26,8 @@ export class Claim implements IClaim {
   @Field()
   @Column()
   requester: string;
+  
+  subject: string;
 
   @Field(() => [String])
   @Column('text', { array: true })


### PR DESCRIPTION
According to JWT specification token subject contained as part of token. As subject is often required part of claim it is better extract  subject and add it to other fields of `Claim` entity on load from database