### PR TITLE
feature/get all enrollments

### DIFF
--- a/src/modules/claim/claim.controller.ts
+++ b/src/modules/claim/claim.controller.ts
@@ -49,6 +49,15 @@ export class ClaimController {
   ) {
     this.logger.setContext(ClaimController.name);
   }
+  
+  @Get('/')
+  @ApiTags('Claims')
+  @ApiOperation({
+    summary: 'returns all claims for all DID',
+  })
+  public async getAllClaims() {
+    return await this.claimService.getAllClaims();
+  }
 
   @Post('/issue/:did')
   @ApiExcludeEndpoint()

--- a/src/modules/claim/claim.service.ts
+++ b/src/modules/claim/claim.service.ts
@@ -140,6 +140,13 @@ export class ClaimService {
     const updatedClaim = Claim.create({ ...claim, ...data, isAccepted: true });
     return this.claimRepository.save(updatedClaim);
   }
+  
+  /**
+   * returns all claims
+   */
+   public async getAllClaims(): Promise<Claim[]> {
+    return this.claimRepository.find();
+  }
 
   /**
    * returns claim with matching ID


### PR DESCRIPTION
Existing claims endpoints doesn't allow to get enrollments for group of assets in one request. It is needed in particular to get claims of offered or previously owned assets. Its seems simpler then adding query parameters to `asset` endpoint especially if in future assets will need to be filtered by other criteria 