### PR TITLE
feature/SWTCH-932 get claims by subject

### DIFF
--- a/src/modules/claim/claim.controller.ts
+++ b/src/modules/claim/claim.controller.ts
@@ -9,6 +9,8 @@ import {
   UseInterceptors,
   HttpException,
   HttpStatus,
+  ValidationPipe,
+  UsePipes,
 } from '@nestjs/common';
 import { ClaimService } from './claim.service';
 import {
@@ -36,6 +38,7 @@ import { Logger } from '../logger/logger.service';
 import { User } from '../../common/user.decorator';
 import { BooleanPipe } from '../../common/boolean.pipe';
 import { AssetsService } from '../assets/assets.service';
+import { DIDsQuery } from './claim.entity';
 
 @Auth()
 @UseInterceptors(SentryErrorInterceptor)
@@ -325,5 +328,22 @@ export class ClaimController {
     accepted?: boolean,
   ) {
     return this.claimService.getDidOfClaimsOfNamespace(namespace, accepted);
+  }
+
+  @UsePipes(new ValidationPipe({ transform: true }))
+  @Get('/by/subjects')
+  @ApiQuery({
+    name: 'dids',
+    required: true,
+    description: 'DIDs whose claims are being requested',
+  })
+  @ApiTags('Claims')
+  @ApiOperation({
+    summary: 'returns claims requested for given DIDs',
+  })
+  public async getBySubjects(
+    @Query() { subjects }: DIDsQuery
+  ) {
+    return this.claimService.getBySubjects(subjects);
   }
 }

--- a/src/modules/claim/claim.controller.ts
+++ b/src/modules/claim/claim.controller.ts
@@ -333,7 +333,7 @@ export class ClaimController {
   @UsePipes(new ValidationPipe({ transform: true }))
   @Get('/by/subjects')
   @ApiQuery({
-    name: 'dids',
+    name: 'subjects',
     required: true,
     description: 'DIDs whose claims are being requested',
   })

--- a/src/modules/claim/claim.service.ts
+++ b/src/modules/claim/claim.service.ts
@@ -150,6 +150,18 @@ export class ClaimService {
   }
 
   /**
+   * returns claims requested for given DIDs
+   * @param subjects claim subjects DIDs
+   */
+  public async getBySubjects(subjects: string[]): Promise<Claim[]> {
+    for (const subject of subjects) {
+      this.logger.debug(subject, 'claims for subject');
+    }
+    const qb = this.claimRepository.createQueryBuilder("claim");
+    return qb.where('claim.subject IN (:...subjects)', { subjects }).getMany();
+  }
+
+  /**
    * returns claims with matching parent namespace
    * eg: passing "A.app" will return all roles in this namespace like "admin.roles.A.app", "user.roles.A.app"
    * @param namespace target parent namespace


### PR DESCRIPTION
Added endpoint `claim/by/subjects`

Endpoint has to consist from 3 path segments to avoid collision with `claim/:id`. Such naming more accurate then currently used `claim/subject/:did`, `claim/parent/:namespace`. 

Should be merged after claim subject column has migrated