### PR TITLE
feature/SWTCH-932 claim subject column

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "docker:down": "docker-compose down -v",
     "build:docs": "rimraf docs/api && typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs true",
     "generate:jwtkeys": "openssl genrsa -out private.pem 2048 && openssl rsa -in private.pem -pubout > public.pem",
+    "migrate:claim-subject": "node src/scripts/migrate_claim_subject.js",
     "migration:generate": "docker-compose run --rm app ./node_modules/.bin/typeorm migration:generate -n",
-    "migration:run": "docker-compose run --rm app ./node_modules/.bin/typeorm migration:run",
+    "migration:run": "docker-compose run --rm app ./node_modules/.bin/typeorm migration:run && npm run migrate:claim-subject",
     "migration:revert": "docker-compose run --rm app ./node_modules/.bin/typeorm migration:revert",
     "migration:create": "docker-compose run --rm app ./node_modules/.bin/typeorm migration:create -n"
   },

--- a/src/migrations/1622032655124-AddClaimSubject.ts
+++ b/src/migrations/1622032655124-AddClaimSubject.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddClaimSubject1622032655124 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn("claim", new TableColumn({ name: 'subject', type: 'varchar', default: "''" }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn("claim", 'subject');
+  }
+
+}

--- a/src/modules/claim/claim.entity.ts
+++ b/src/modules/claim/claim.entity.ts
@@ -27,6 +27,7 @@ export class Claim implements IClaim {
   @Column()
   requester: string;
   
+  @Column()
   subject: string;
 
   @Field(() => [String])

--- a/src/scripts/migrate_claim_subject.js
+++ b/src/scripts/migrate_claim_subject.js
@@ -1,0 +1,33 @@
+const { createConnection, TableColumn } = require('typeorm');
+const { JWT } = require('@ew-did-registry/jwt');
+const { Keys } = require('@ew-did-registry/keys');
+const { Claim } = require('../../dist/modules/claim/claim.entity.js');
+
+(async function () {
+  const connection = await createConnection({
+    // had to copy from orgmconfig because typeorm doesn't detect postgres driver
+    type: "postgres",
+    host: "localhost",
+    port: 5432,
+    username: "postgres",
+    password: "password",
+    database: "dev",
+    "entities": [
+      "dist/**/*.entity.js"
+    ]
+  });
+  const claimsRepository = connection.getRepository(Claim);
+  let claims = await claimsRepository.find();
+
+  const jwt = new JWT(new Keys());
+  for await (const claim of claims) {
+    const payload = jwt.decode(claim.token);
+    let subject = payload.sub;
+    if (!subject || subject.length === 0 || !subject.startsWith("did")) {
+      subject = payload.iss;
+    }
+    await claimsRepository.update(claim.id, { ...claim, subject });
+  }
+  
+  await connection.close();
+}());


### PR DESCRIPTION
Adds `subject` column in `claims` table and populates it with `sub` of decoded claim's token

Blocks: https://github.com/energywebfoundation/iam-cache-server/pull/120

