### PR TITLE
fix(role.service): check for empty conditions array

### DIFF
--- a/src/modules/role/role.service.ts
+++ b/src/modules/role/role.service.ts
@@ -162,7 +162,7 @@ export class RoleService {
 
     if (!enrolmentPreconditions || enrolmentPreconditions.length < 1) return;
     for (const { type, conditions } of enrolmentPreconditions) {
-      if (type === 'role' && conditions) {
+      if (type === 'role' && conditions && conditions?.length > 0) {
         const conditionMet = didDocument.service.some(
           ({ claimType }) =>
             claimType && conditions.includes(claimType as string),


### PR DESCRIPTION
Same fix that was made here: https://github.com/energywebfoundation/iam-client-lib/commit/560f85a801a889469f430b34e91576cff2735202

Fix was already made to `develop` but needs to be pushed to `master` https://github.com/energywebfoundation/iam-cache-server/commit/1d446d3de10422ec1f660d3209d5c2876589d61c#diff-25a6634263c1b1f6fc4697a04e2b9904ea4b042a89af59dc93ec1f5d44848a26

Partially fixes: https://energyweb.atlassian.net/browse/SWTCH-982