### PR TITLE
fix: update iam-contracts to fix ENS Sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1211,9 +1211,9 @@
       }
     },
     "@energyweb/iam-contracts": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@energyweb/iam-contracts/-/iam-contracts-1.10.1.tgz",
-      "integrity": "sha512-feBHPT3z37HpQMDdUa7jpjb2e5NXwLpcnPjDi9OITzahsNGR7djqk1ffeDteMSLNwRGZMY3L6MRY/Y8oEUfukw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@energyweb/iam-contracts/-/iam-contracts-1.11.1.tgz",
+      "integrity": "sha512-3BnZgcoKE3aQd0qHH4wilNqh9ufdFvmgWgMNkcCoJ+bzDNWhODHZyNLkmY0xcxvjqTVsjLspn7pNJNGAfj+g5w==",
       "requires": {
         "@openzeppelin/contracts": "3.4.1",
         "ethers": "4.0.45"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@ensdomains/ens": "^0.4.5",
     "@ensdomains/resolver": "^0.2.4",
-    "@energyweb/iam-contracts": "1.10.1",
+    "@energyweb/iam-contracts": "1.11.1",
     "@ew-did-registry/did-document": "0.5.2-alpha.1041.0",
     "@ew-did-registry/did-ethr-resolver": "0.5.2-alpha.1041.0",
     "@ew-did-registry/did-ipfs-store": "0.5.2-alpha.1041.0",


### PR DESCRIPTION
ENS Sync can now handle deleted namespace
https://energyweb.atlassian.net/browse/SWTCH-997