### PR TITLE
SWTCH-1043 only return IDIDDocument

### DIFF
--- a/src/modules/did/did.service.spec.ts
+++ b/src/modules/did/did.service.spec.ts
@@ -1,13 +1,76 @@
+import { getQueueToken } from '@nestjs/bull';
+import { HttpService, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Provider } from '../../common/provider';
+import { DIDDocumentEntity } from './did.entity';
 import { DIDService } from './did.service';
 
-// TODO: fix test so pending can be removed
-xdescribe('DidDocumentService', () => {
+const MockLogger = {
+  log: jest.fn(),
+  setContext: jest.fn(),
+};
+const MockObject = {};
+const MockConfigService = {
+  get: jest.fn((key: string) => {
+    if (key === 'DID_SYNC_ENABLED') {
+      return 'false';
+    }
+    return null;
+  }),
+};
+const repositoryMockFactory = jest.fn(() => ({
+  findOne: jest.fn(entity => entity),
+}));
+const queueMockFactory = jest.fn(() => ({
+}));
+jest.mock('@ew-did-registry/did-ipfs-store', () => {
+  return {
+    DidStore: jest.fn().mockImplementation(() => { return {} })
+  }
+});
+jest.mock('@ew-did-registry/did-ethr-resolver', () => ({
+  ...jest.requireActual('@ew-did-registry/did-ethr-resolver') as Record<string, unknown>,
+  Resolver: jest.fn().mockImplementation(() => { return {} })
+}));
+jest.mock('../../ethers/EthereumDidRegistryFactory', () => ({
+  EthereumDidRegistryFactory: {
+    connect: jest.fn(() => {
+      return {
+        addEventListener: jest.fn()
+      }
+    })
+  }
+}));
+
+describe('DidDocumentService', () => {
   let service: DIDService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DIDService],
+      providers: [DIDService,
+        {
+          provide: ConfigService,
+          useValue: MockConfigService
+        },
+        {
+          provide: SchedulerRegistry,
+          useValue: MockObject
+        },
+        {
+          provide: HttpService,
+          useValue: MockObject
+        },
+        {
+          provide: Logger,
+          useValue: MockLogger
+        },
+        { provide: getQueueToken('dids'), useFactory: queueMockFactory },
+        { provide: getRepositoryToken(DIDDocumentEntity), useFactory: repositoryMockFactory },
+        { provide: Provider, useValue: MockObject }
+      ]
     }).compile();
 
     service = module.get<DIDService>(DIDService);

--- a/src/modules/did/did.service.spec.ts
+++ b/src/modules/did/did.service.spec.ts
@@ -25,8 +25,17 @@ const MockConfigService = {
     return null;
   }),
 };
+const didDoc: IDIDDocument = {
+  id: "<id>",
+  service: [],
+  authentication: [],
+  publicKey: [],
+  created: "<created>",
+  proof: undefined,
+  updated: "<updated>",
+  '@context': "<context>"
+};
 let didDocEntity: DIDDocumentEntity;
-let didDoc: IDIDDocument
 const repositoryMockFactory = jest.fn(() => ({
   findOne: jest.fn(() => {
     return didDocEntity;
@@ -75,17 +84,6 @@ describe('DidDocumentService', () => {
       ]
     }).compile();
 
-    didDoc = {
-      id: "<id>",
-      service: [],
-      authentication: [],
-      publicKey: [],
-      created: "<created>",
-      proof: undefined,
-      updated: "<updated>",
-      '@context': "<context>"
-    };
-    didDocEntity = Object.assign(didDoc, { logs: "<logs>" })
     service = module.get<DIDService>(DIDService);
   });
 
@@ -93,17 +91,22 @@ describe('DidDocumentService', () => {
     expect(service).toBeDefined();
   });
 
-  // Would be better done by exact types: https://github.com/Microsoft/TypeScript/issues/12936
   it('getByID should return only IDIDDocument params from cached document', async () => {
-    const didDoc = await service.getById("<any DID>");
-    expect(didDoc).toBeDefined();
-    expect(didDoc[nameof<DIDDocumentEntity>("logs")]).toBeUndefined();
+    didDocEntity = Object.assign({}, didDoc, { logs: "<logs>" })
+    const returnedDoc = await service.getById("<any DID>");
+    checkReturnedDIDDoc(returnedDoc);
   });
 
   it('getByID should return only IDIDDocument params from non-cached document', async () => {
     didDocEntity = undefined;
-    const didDoc = await service.getById("<any DID>");
-    expect(didDoc).toBeDefined();
-    expect(didDoc[nameof<DIDDocumentEntity>("logs")]).toBeUndefined();
+    const returnedDoc = await service.getById("<any DID>");
+    checkReturnedDIDDoc(returnedDoc);
   });
+
+  function checkReturnedDIDDoc(returnedDoc: IDIDDocument) {
+    for (const property in returnedDoc) {
+      expect(returnedDoc[property]).toStrictEqual(didDoc[property]);
+    }
+    expect(returnedDoc[nameof<DIDDocumentEntity>("logs")]).toBeUndefined();
+  }
 });

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -88,10 +88,22 @@ export class DIDService {
    * @returns {IDIDDocument} Resolved DID Document.
    */
   public async getById(did: string): Promise<IDIDDocument> {
+    const convertToIDIDDocument = (entity: DIDDocumentEntity): IDIDDocument => {
+      return {
+        '@context': entity['@context'],
+        authentication: entity.authentication,
+        created: entity.created,
+        delegates: entity.delegates,
+        id: entity.id,
+        service: entity.service,
+        publicKey: entity.publicKey,
+        proof: entity.proof,
+        updated: entity.updated
+      }
+    }
     const cachedDIDDocument = await this.didRepository.findOne(did);
     if (cachedDIDDocument) {
-      delete cachedDIDDocument.logs;
-      return cachedDIDDocument;
+      return convertToIDIDDocument(cachedDIDDocument);
     }
 
     this.logger.info(
@@ -99,8 +111,7 @@ export class DIDService {
     );
 
     const entity = await this.addCachedDocument(did);
-    delete entity.logs;
-    return entity;
+    return convertToIDIDDocument(entity);
   }
 
   /**

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -90,13 +90,18 @@ export class DIDService {
    */
   public async getById(did: string): Promise<IDIDDocument> {
     const cachedDIDDocument = await this.didRepository.findOne(did);
-    if (cachedDIDDocument) return cachedDIDDocument;
+    if (cachedDIDDocument) {
+      delete cachedDIDDocument.logs;
+      return cachedDIDDocument;
+    }
 
     this.logger.info(
-      `Requested document for did: ${did} not cached. Queuing cache request.`,
+      `Requested document for did: ${did} not cached. Add to cache.`,
     );
 
-    return this.addCachedDocument(did);
+    const entity = await this.addCachedDocument(did);
+    delete entity.logs;
+    return entity;
   }
 
   /**


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/SWTCH-1043

- [x] test(did.service): service defined with mock dependencies
- [x] only return IDIDDocument from getDocument