### PR TITLE
Fix/swtch 1042 include claims param

### DIFF
--- a/src/modules/did/did.controller.ts
+++ b/src/modules/did/did.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, UseInterceptors } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SentryErrorInterceptor } from '../interceptors/sentry-error-interceptor';
 import { Logger } from '../logger/logger.service';
 import { Auth } from '../auth/auth.decorator';
@@ -31,12 +31,6 @@ export class DIDController {
     description:
       'Returns a resolved DID Document, optionally with full claim data. \n' +
       'If DID Document is not yet cached, it is retrieved from the blockchain',
-  })
-  @ApiQuery({
-    name: 'includeClaims',
-    required: false,
-    description:
-      'If true, includes parsed claim JWT data in service endpoint objects',
   })
   @UseInterceptors(NotFoundInterceptor)
   public async getById(@Param('did') id: string) {

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -83,10 +83,9 @@ export class DIDService {
   }
 
   /**
-   * Retrieves a DID Document for a given DID
-   * @param {DID} did DID whose document should be retrieved
-   * @param {boolean} enhanceWithClaims
-   * @returns {IDIDDocument} Resolved DID Document. Null if no Document is not cached.
+   * Retrieves a DID Document for a given DID. Retrieves from blockchain if not cached.
+   * @param {string} did DID whose document should be retrieved
+   * @returns {IDIDDocument} Resolved DID Document.
    */
   public async getById(did: string): Promise<IDIDDocument> {
     const cachedDIDDocument = await this.didRepository.findOne(did);
@@ -102,7 +101,7 @@ export class DIDService {
   /**
    * Adds the DID Document cache for a given DID.
    * Also retrieves all claims from IPFS for the document.
-   * @param {DID} did
+   * @param {string} did
    */
   public async addCachedDocument(did: string) {
     try {
@@ -131,7 +130,7 @@ export class DIDService {
   /**
    * Refresh the DID Document cache for a given DID.
    * Also retrieves all claims from IPFS for the document.
-   * @param {DID} did
+   * @param {string} did
    */
   public async refreshCachedDocument(did: string) {
     try {


### PR DESCRIPTION
- fix(did.controller): removed `includeClaims` param as not respected. DID document services are being persisted directly with claimData so hard to separate at this point. Should not break anyone who is using `includeClaims` as they will still get the data
- docs(did.service): corrected some documentation