### PR TITLE
refactor(HttpModule): use HttpModule from @nest/axios

### DIFF
--- a/src/modules/did/did.module.ts
+++ b/src/modules/did/did.module.ts
@@ -1,5 +1,6 @@
 import { BullModule } from '@nestjs/bull';
-import { HttpModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Provider } from '../../common/provider';
 import { DIDController } from './did.controller';

--- a/src/modules/did/did.service.spec.ts
+++ b/src/modules/did/did.service.spec.ts
@@ -1,6 +1,6 @@
 import { IDIDDocument } from '@ew-did-registry/did-resolver-interface';
 import { getQueueToken } from '@nestjs/bull';
-import { HttpService } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { Test, TestingModule } from '@nestjs/testing';

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -6,9 +6,11 @@ import {
 } from '@ew-did-registry/did-resolver-interface';
 import { DidStore } from '@ew-did-registry/did-ipfs-store';
 import { IDidStore } from '@ew-did-registry/did-store-interface';
-import { HttpService, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { firstValueFrom } from 'rxjs';
 import { EthereumDidRegistryFactory } from '../../ethers/EthereumDidRegistryFactory';
 import { EthereumDidRegistry } from '../../ethers/EthereumDidRegistry';
 import { InjectQueue } from '@nestjs/bull';
@@ -189,9 +191,11 @@ export class DIDService {
       throw new Error('universal resolver url not set');
     }
     const stripTrailingSlash = (s: string) => s.replace(/\/$/, ''); //https://stackoverflow.com/questions/6680825/return-string-without-trailing-slash
-    const { data } = await this.httpService
-      .get(`${stripTrailingSlash(universalResolverUrl)}/${did}`)
-      .toPromise();
+    const observableResponse = this.httpService.get(
+      `${stripTrailingSlash(universalResolverUrl)}/${did}`,
+    );
+    const { data } = await firstValueFrom(observableResponse);
+
     return data.didDocument;
   }
 


### PR DESCRIPTION
Use HttpModule and HttpService from @nest/axios instead of @nest/common because of deprecation.