### PR TITLE
bug/ICS-141 access tokens are sent to sentry

### DIFF
--- a/src/modules/sentry/sentry.service.ts
+++ b/src/modules/sentry/sentry.service.ts
@@ -41,12 +41,14 @@ export class SentryService {
         const request = event.request;
         if (request) {
           delete request.cookies;
+          delete request.data.identityToken;
+          request.url.replace(/refresh_token=.*/, 'refresh_token=[Filtered]');
           const headers = request.headers;
           if (headers) {
+            delete headers['Authorization'];
             delete headers.cookie;
           }
         }
-
         return event;
       },
     });

--- a/src/modules/sentry/sentry.service.ts
+++ b/src/modules/sentry/sentry.service.ts
@@ -37,6 +37,18 @@ export class SentryService {
         }),
         new Sentry.Integrations.OnUnhandledRejection({ mode: 'warn' }),
       ],
+      beforeSend(event) {
+        const request = event.request;
+        if (request) {
+          delete request.cookies;
+          const headers = request.headers;
+          if (headers) {
+            delete headers.cookie;
+          }
+        }
+
+        return event;
+      },
     });
   }
 

--- a/src/modules/sentry/sentry.service.ts
+++ b/src/modules/sentry/sentry.service.ts
@@ -41,7 +41,7 @@ export class SentryService {
         const request = event.request;
         if (request) {
           delete request.cookies;
-          delete request.data.identityToken;
+          delete request.data?.identityToken;
           request.url.replace(/refresh_token=.*/, 'refresh_token=[Filtered]');
           const headers = request.headers;
           if (headers) {


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/ICS-141
- [x] strip access and refresh tokens from request cookies and headers
- [x]  strip refresh token from request query
- [x] remove identityToken from request body