### PR TITLE
fix(claims): ensure only one event is propagated to each notified DID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15557,6 +15557,12 @@
         }
       }
     },
+    "jest-create-mock-instance": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-create-mock-instance/-/jest-create-mock-instance-2.0.0.tgz",
+      "integrity": "sha512-gW3H87m8hF72JMFPMEorF2jnEyV31XpaOYtDqeRNSwFT73+MNZvbUKQfCbdixxOrCCppToSPmi9gGygIzms6Eg==",
+      "dev": true
+    },
     "jest-diff": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "eslint-plugin-import": "^2.20.1",
     "husky": "^4.3.8",
     "jest": "27.0.6",
+    "jest-create-mock-instance": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "lint-staged": "^11.1.1",
     "npm-run-all": "^4.1.5",

--- a/src/modules/claim/claim.controller.ts
+++ b/src/modules/claim/claim.controller.ts
@@ -90,11 +90,19 @@ export class ClaimController {
       throw new HttpException(result.details, HttpStatus.BAD_REQUEST);
     }
 
-    const { sub } = new JWT(new Keys()).decode(claimData.issuedToken) as { sub:string };
+    const dids = [claimData.requester];
+
+    if (claimData.issuedToken) {
+      const { sub } = new JWT(new Keys()).decode(claimData.issuedToken) as {
+        sub: string;
+      };
+      dids.push(sub);
+    }
+
     await this.nats.publishForDids(
       ClaimEventType.ISSUE_CREDENTIAL,
       NATS_EXCHANGE_TOPIC,
-      [claimData.requester, sub as string],
+      dids,
       { claimId: claimData.id },
     );
 

--- a/src/modules/nats/nats.service.spec.ts
+++ b/src/modules/nats/nats.service.spec.ts
@@ -1,19 +1,51 @@
+import { BullModule, getQueueToken } from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import createMockInstance from 'jest-create-mock-instance';
+import { Logger } from '../logger/logger.service';
 import { NatsService } from './nats.service';
+import { NatsWrapper } from './nats.wrapper';
 
-// TODO: fix test so pending can be removed
-xdescribe('NatsService', () => {
+describe.only('NatsService', () => {
+  let mockedNats: jest.Mocked<NatsWrapper>;
   let service: NatsService;
-
+  const QUEUE_NAME = 'nats-messages';
+  let mockQueue;
   beforeEach(async () => {
+    mockedNats = createMockInstance(NatsWrapper);
+    mockQueue = {
+      add: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NatsService],
-    }).compile();
+      imports: [
+        BullModule.registerQueue({
+          name: QUEUE_NAME,
+        }),
+      ],
+      providers: [NatsService, NatsWrapper, ConfigService, Logger],
+    })
+      .overrideProvider(getQueueToken(QUEUE_NAME))
+      .useValue(mockQueue)
+      .overrideProvider(NatsWrapper)
+      .useValue(mockedNats)
+      .compile();
 
     service = module.get<NatsService>(NatsService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should send same event to every did only once', async () => {
+    await service.publishForDids(
+      'rt',
+      'topic1',
+      ['did1', 'did2', 'did3', 'did1', 'did2', 'did1'],
+      { data: 'some data' },
+    );
+
+    expect(mockQueue.add).toBeCalledTimes(3);
   });
 });

--- a/src/modules/nats/nats.service.ts
+++ b/src/modules/nats/nats.service.ts
@@ -29,7 +29,7 @@ export class NatsService {
     data: Record<string, unknown>,
   ) {
     await Promise.all(
-      dids.map(did =>
+      [...new Set(dids)].map(did =>
         this.messagesQueue.add('message', {
           subject: `${requestType}.${topic}.${did}.${this.natsEnvironmentName}`,
           data: { type: requestType, ...data },


### PR DESCRIPTION
remove duplicated DIDs , fixed problem with wrong subject in case of issuedToken not present