### PR TITLE
build: renable commitlint

### DIFF
--- a/.github/workflows/cache_server.test.yml
+++ b/.github/workflows/cache_server.test.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Check linting
         run: npm run lint
 
-      # - name: Run Commitlint
-      #   run: npx commitlint --from HEAD~1 --verbose
+      - name: Run Commitlint
+        run: npx commitlint --from HEAD~1 --verbose
 
       - name: Audit package dependencies
         run: npm audit --audit-level=critical


### PR DESCRIPTION
It was disabled because we had old commits
which didn't pass commitlint which we had to merge into master
But now all commit should be conform to conventional commit