### PR TITLE
chore(renovate): remove base branch option

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["github>energywebfoundation/shared-configs"],
   "assignees": ["Harasz", "JGiter"],
-  "reviewers": ["Harasz", "jrhender", "JGiter"],
-  "baseBranches": ["develop"]
+  "reviewers": ["Harasz", "jrhender", "JGiter"]
 }


### PR DESCRIPTION
Since we've change base branch to `develop` we don't need to override this option anymore